### PR TITLE
Fixes race condition

### DIFF
--- a/gpm
+++ b/gpm
@@ -16,10 +16,12 @@ set -eu
 set_dependencies() {
   while read package version; do
     (
+      install_path="${GOPATH%%:*}/src/${package%%/...}"
+      [[ -e "$install_path/.git/index.lock" ]] && wait
       echo ">> Getting package "$package""
       go get -u -d "$package"
       echo ">> Setting $package to version $version"
-      cd "${GOPATH%%:*}/src/${package%%/...}"
+      cd $install_path
       git checkout -q "$version"
     ) &
   done < <(echo "$deps")


### PR DESCRIPTION
In the case that two dependencies are affecting the same package we'll have to
check for a lock in the install dir. If exists just wait for the other child
processes to finish.
