### PR TITLE
Adds support or mercurial and bazaar

### DIFF
--- a/gpm
+++ b/gpm
@@ -22,10 +22,13 @@ set_dependencies() {
       go get -u -d "$package"
       echo ">> Setting $package to version $version"
       cd $install_path
-      git checkout -q "$version"
+      [ -d .hg ] && hg update -q "$version"
+      [ -d .git ] && git checkout -q "$version"
+      [ -d .bzr ] && bzr revert -q -r "$version"
     ) &
   done < <(echo "$deps")
   wait
+  echo ">> All Done"
 }
 
 # Gets latest release or HEAD for a project and adds it to Godeps unless it's already there.

--- a/test/support_for_major_vcs_test.sh
+++ b/test/support_for_major_vcs_test.sh
@@ -1,0 +1,18 @@
+. assert.sh
+
+echo "
+# Bazaar Repos
+launchpad.net/gocheck                     r2013.03.03
+
+# Mercurial Repos
+code.google.com/p/go.example/hello/...    ae081cd1d6cc
+
+# Git Repos
+github.com/nu7hatch/gotrail               v0.0.2
+" > testGodeps
+
+../gpm -f testGodeps
+assert "echo "$?"" "0"
+rm testGodeps
+
+assert_end examples


### PR DESCRIPTION
This is skipping subversion support, which does work with go get. But nobody seems to be using that so I think I will drop it for now until there is a need for it.

Closes #6
