### PR TITLE
allow versioning of subversion-based dependencies

### DIFF
--- a/bin/gpm
+++ b/bin/gpm
@@ -52,6 +52,7 @@ set_dependencies() {
       [ -d .hg ]  && hg update    -q      "$version"
       [ -d .git ] && git checkout -q      "$version"
       [ -d .bzr ] && bzr revert   -q -r   "$version"
+      [ -d .svn ] && svn update   -r      "$version"
     ) &
   done < <(echo "$deps")
   wait


### PR DESCRIPTION
Pretty simple/obvious, but I noticed this was not supported just a few minutes ago.
