### PR TITLE
Use `command` to check if the plugin is available

### DIFF
--- a/bin/gpm
+++ b/bin/gpm
@@ -76,7 +76,7 @@ case "${1:-"install"}" in
     ;;
   *)
     ## Support for Plugins: if command is unknown search for a gpm-command executable.
-    (which "gpm-$1" > /dev/null &&
+    (command -v "gpm-$1" > /dev/null &&
       plugin=$1 &&
       shift     &&
       gpm-$plugin $@ &&


### PR DESCRIPTION
I recently looked into a lot of shell stuff, especially what really is POSIX-compatible and the best ways to do several things.
From what I found it's best to not use `which`, but instead shell built-ins to determine if a command is available. `command` is available everywhere, fully specified in POSIX and will definitely set the correct exit code. Read [Stack Overflow](http://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script/677212#677212) for more.

Thanks for this small project. I really like it. :)
