### PR TITLE
Use #!/usr/bin/env sh rather than #!/bin/bash

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 prefix=/usr/local
 


### PR DESCRIPTION
FreeBSD (and other) environments don't have bash installed to `/bin/bash`. To support these platforms the shell in the configure script should use `#!/usr/bin/env sh`.

It's possible that on some systems `bash` is required depending on their distros version of `sh`, however, FreeBSD's `sh` is pretty bare bones and the configure script works fine with this amendment. My knowledge of the POSIX.1 compatibility of various distros is somewhat sparse but if travis passes for this PR then it is safe to assume that the majority of Linux users won't see problems with this change.
