### PR TITLE
Add support for DESTDIR convention to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ all:
 	-@echo Nothing to do...
 
 install:
-	install -d $(prefix)/bin
-	install -m 0755 ./bin/gpm $(prefix)/bin
+	install -d $(DESTDIR)$(prefix)/bin
+	install -m 0755 ./bin/gpm $(DESTDIR)$(prefix)/bin
 
 test:
 	cd test && ./run_all_tests.sh


### PR DESCRIPTION
This makes it possible to do, eg. ```make install DESTDIR=/var/tmp/installdir``` for packaging purposes.