### PR TITLE
Install packages after downloading.

### DIFF
--- a/bin/gpm
+++ b/bin/gpm
@@ -66,6 +66,12 @@ set_dependencies() {
     ) &
   done < <(echo "$deps")
   wait
+
+  while read package version; do
+    echo ">> Building package "$package""
+    go install "$package"
+  done < <(echo "$deps")
+
   echo ">> All Done"
 }
 ## /Functions


### PR DESCRIPTION
This change adds another loop to install all packages after downloading. It is
similar to the [prebuild](https://github.com/technosophos/gpm-prebuild) 
plugin. It doesn't run in parallel.

The main difference is that it won't run `go install $package/...`. This is a
somewhat confusing on prebuild, and fails with some repos, since
`go get` is made to work with packages, not repos.

A possible solution would be to add the wildcard to the dependency itself, in
the Gofile.

Regardless, this is a possible start that should at least work safely for the
majority of use cases.

Original discussion [here](https://github.com/pote/gpm/issues/58)