### PR TITLE
`gpm get` to only get packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ gpm has the following commands:
 
 ```bash
 $ gpm             # Same as 'install'.
+$ gpm get         # Parses the Godeps file, gets dependencies and sets them
+                  # to the appropriate version but does not install them.
 $ gpm install     # Parses the Godeps file, installs dependencies and sets
                   # them to the appropriate version.
 $ gpm version     # Outputs version information

--- a/bin/gpm
+++ b/bin/gpm
@@ -2,8 +2,6 @@
 
 set -eu
 
-no_install=false
-
 ## Functions/
 usage() {
 cat << EOF
@@ -45,18 +43,23 @@ is_in_use() {
 # Exit with an error message to stderr. An optional second argument sets the
 # exit status (defaults to `1`).
 abort() {
-	echo "$1" >&2;
-	exit ${2:-1};
+  echo "$1" >&2;
+  exit ${2:-1};
 }
 
-# Iterates over Godep file dependencies and sets
-# the specified version on each of them.
-set_dependencies() {
-  local deps=$(sed 's/#.*//;/^\s*$/d' < $1) || echo ""
+# Download dependencies and set their current versions to those specified in
+# the Godeps file (the path to which should be passed as the first argument).
+get_dependencies() {
+  (command -v go >/dev/null) ||
+    abort ">> Go is currently not installed or in your PATH"
+  [ -z "${GOPATH:-}" ] && abort ">> GOPATH is not set"
 
-  while read package version; do
+  [[ -r "$1" ]] || abort ">> $1 file does not exist."
+  local deps=$(sed 's/#.*//;/^\s*$/d' < "$1") || echo ""
+
+  while read package _; do
     (
-      echo ">> Getting package "$package""
+      echo ">> Getting package "$package"" >&3
       go get -u -d "$package"
     ) &
   done < <(echo "$deps")
@@ -66,7 +69,7 @@ set_dependencies() {
     (
       local pkg_path=$(echo "$package" | awk -F/ '{print $1"/"$2"/"$3}')
       local install_path="${GOPATH%%:*}/src/${pkg_path%%/...}"
-      echo ">> Setting $package to version $version"
+      echo ">> Setting $package to version $version" >&3
       cd "$install_path"
       is_in_use $install_path && wait
 
@@ -78,24 +81,17 @@ set_dependencies() {
   done < <(echo "$deps")
   wait
 
-  if [[ $no_install != true ]]
-  then
-    while read package version; do
-      echo ">> Building package "$package""
-      go install "$package"
-    done < <(echo "$deps")
-  fi
-
-  echo ">> All Done"
+  echo "$deps"
 }
 
-start() {
-  deps_file="${1:-"Godeps"}"
-  [[ -r "$deps_file" ]] || abort ">> $deps_file file does not exist."
-  (which go > /dev/null) ||
-    abort ">> Go is currently not installed or in your PATH"
-  [ -z "${GOPATH:-}" ] && abort ">> GOPATH is not set"
-  set_dependencies $deps_file
+# Reads dependencies from input and installs the packages.
+install_dependencies() {
+  while read package _; do
+    echo ">> Building package "$package"" >&3
+    go install "$package"
+  done
+
+  echo ">> All Done" >&3
 }
 
 ## /Functions
@@ -106,14 +102,13 @@ case "${1:-"install"}" in
     echo ">> gpm v1.3.2"
     ;;
   "install")
-    start $2
+    (get_dependencies "${2:-"Godeps"}" | install_dependencies) 3>&1
+    ;;
+  "get")
+    get_dependencies "${2:-"Godeps"}" 3>&1 >/dev/null
     ;;
   "help")
     usage
-    ;;
-  "get")
-    no_install=true
-    start
     ;;
   *)
     ## Support for Plugins: if command is unknown search for a gpm-command executable.

--- a/bin/gpm
+++ b/bin/gpm
@@ -2,6 +2,8 @@
 
 set -eu
 
+no_install=false
+
 ## Functions/
 usage() {
 cat << EOF
@@ -27,6 +29,8 @@ SYNOPSIS
 
 USAGE
       $ gpm             # Same as 'install'.
+      $ gpm get         # Parses the Godeps file, gets dependencies and sets them
+                        # to the appropriate version but does not install them. 
       $ gpm install     # Parses the Godeps file, installs dependencies and sets
                         # them to the appropriate version.
       $ gpm version     # Outputs version information
@@ -74,13 +78,26 @@ set_dependencies() {
   done < <(echo "$deps")
   wait
 
-  while read package version; do
-    echo ">> Building package "$package""
-    go install "$package"
-  done < <(echo "$deps")
+  if [[ $no_install != true ]]
+  then
+    while read package version; do
+      echo ">> Building package "$package""
+      go install "$package"
+    done < <(echo "$deps")
+  fi
 
   echo ">> All Done"
 }
+
+start() {
+  deps_file="${1:-"Godeps"}"
+  [[ -r "$deps_file" ]] || abort ">> $deps_file file does not exist."
+  (which go > /dev/null) ||
+    abort ">> Go is currently not installed or in your PATH"
+  [ -z "${GOPATH:-}" ] && abort ">> GOPATH is not set"
+  set_dependencies $deps_file
+}
+
 ## /Functions
 
 ## Command Line Parsing
@@ -89,15 +106,14 @@ case "${1:-"install"}" in
     echo ">> gpm v1.3.2"
     ;;
   "install")
-    deps_file="${2:-"Godeps"}"
-    [[ -r "$deps_file" ]] || abort ">> $deps_file file does not exist."
-    (which go > /dev/null) ||
-      abort ">> Go is currently not installed or in your PATH"
-    [ -z "${GOPATH:-}" ] && abort ">> GOPATH is not set"
-    set_dependencies $deps_file
+    start $2
     ;;
   "help")
     usage
+    ;;
+  "get")
+    no_install=true
+    start
     ;;
   *)
     ## Support for Plugins: if command is unknown search for a gpm-command executable.

--- a/test/installs_correct_versions_test.sh
+++ b/test/installs_correct_versions_test.sh
@@ -13,8 +13,9 @@ assert "go run go_code.go" "v6.2"
 version="a6a0a737c00caf4d4c2bb589941ace0d688168bb"
 echo "github.com/garyburd/redigo/redis $version" > Godeps
 assert_raises "$GPM"
-cd "${GOPATH%%:*}/src/github.com/garyburd/redigo"
+pushd "${GOPATH%%:*}/src/github.com/garyburd/redigo"
 assert "git rev-parse HEAD" "$version"
+popd
 
 ## Cleanup
 rm Godeps


### PR DESCRIPTION
Builds on the work of @eatonphil on #76. Splits `set_dependencies` into `get_dependencies` and `install_dependencies`.

In order to maintain output (and correct usage of stdout and stderr) does some file descriptor juggling, using fd=3 to pass around information from either functions for things that should be output to the user.

I'm seeing a couple tests failing locally, but I think it's due to changes in redigo that are breaking the tests. This is working from my tests using my dev version to get / install packages :)

cc @pote 